### PR TITLE
Get v50 compiling

### DIFF
--- a/library/Hooks-windows.cpp
+++ b/library/Hooks-windows.cpp
@@ -664,6 +664,13 @@ DFhackCExport void SDL_DestroySemaphore(void *sem)
     _SDL_DestroySemaphore(sem);
 }
 
+static vPtr (*_SDL_ListModes)(vPtr format, uint32_t flags) = 0;
+DFhackCExport vPtr SDL_ListModes(vPtr format, uint32_t flags)
+{
+    InitSDLPointers();
+    return _SDL_ListModes(format, flags);
+}
+
 static uint8_t (*_SDL_GetAppState)(void) = 0;
 DFhackCExport uint8_t SDL_GetAppState(void)
 {
@@ -816,6 +823,9 @@ void FirstCall()
     // new in DF 0.43.05
     _SDL_getenv = (char* (*)(const char*))GetProcAddress(realSDLlib,"SDL_getenv");
     _SDL_strlcat = (size_t (*)(char*, const char*, size_t))GetProcAddress(realSDLlib,"SDL_strlcat");
+
+    // new in DF v50.01
+    _SDL_ListModes = (void *(*)(void*, uint32_t))GetProcAddress(realSDLlib,"SDL_ListModes");
 
     _SDL_EnableUNICODE(1);
 

--- a/library/include/modules/Screen.h
+++ b/library/include/modules/Screen.h
@@ -336,6 +336,7 @@ namespace DFHack
 
         virtual void logic();
         virtual void render();
+        virtual void resize(int w, int h) { return; }
 
         virtual int8_t movies_okay() { return 1; }
         virtual bool key_conflict(df::interface_key key);

--- a/library/include/modules/Screen.h
+++ b/library/include/modules/Screen.h
@@ -178,6 +178,7 @@ namespace DFHack
         };
 
         DFHACK_EXPORT df::coord2d getMousePos();
+        DFHACK_EXPORT df::coord2d getMousePixels();
         DFHACK_EXPORT df::coord2d getWindowSize();
 
         inline rect2d getScreenRect() {

--- a/library/modules/Buildings.cpp
+++ b/library/modules/Buildings.cpp
@@ -219,7 +219,7 @@ df::specific_ref *Buildings::getSpecificRef(df::building *building, df::specific
 bool Buildings::setOwner(df::building *bld, df::unit *unit)
 {
     CHECK_NULL_POINTER(bld);
-
+/* TODO: understand how this changes for v50
     if (!bld->is_room)
         return false;
     if (bld->owner == unit)
@@ -255,6 +255,7 @@ bool Buildings::setOwner(df::building *bld, df::unit *unit)
     {
         bld->owner_id = -1;
     }
+*/
 
     return true;
 }
@@ -457,12 +458,14 @@ df::building *Buildings::allocInstance(df::coord pos, df::building_type type, in
         }
         break;
     }
+/* TODO: understand how this changes for v50
     case building_type::Coffin:
     {
         if (VIRTUAL_CAST_VAR(obj, df::building_coffinst, bld))
             obj->initBurialFlags(); // DF has this copy&pasted
         break;
     }
+*/
     case building_type::Trap:
     {
         if (VIRTUAL_CAST_VAR(obj, df::building_trapst, bld))
@@ -786,8 +789,10 @@ bool Buildings::containsTile(df::building *bld, df::coord2d tile, bool room)
 
     if (room)
     {
+/* TODO: understand how this changes for v50
         if (!bld->is_room || !bld->room.extents)
             return false;
+*/
     }
     else
     {
@@ -961,6 +966,7 @@ static void markBuildingTiles(df::building *bld, bool remove)
 
 static void linkRooms(df::building *bld)
 {
+/* TODO: understand how this changes for v50
     auto &vec = world->buildings.other[buildings_other_id::IN_PLAY];
 
     bool changed = false;
@@ -984,10 +990,12 @@ static void linkRooms(df::building *bld)
 
     if (changed)
         df::global::ui->equipment.update.bits.buildings = true;
+*/
 }
 
 static void unlinkRooms(df::building *bld)
 {
+/* TODO: understand how this changes for v50
     for (size_t i = 0; i < bld->parents.size(); i++)
     {
         auto parent = bld->parents[i];
@@ -996,6 +1004,7 @@ static void unlinkRooms(df::building *bld)
     }
 
     bld->parents.clear();
+*/
 }
 
 static void linkBuilding(df::building *bld)
@@ -1044,6 +1053,7 @@ static int getMaxStockpileId()
     return max_id;
 }
 
+/* TODO: understand how this changes for v50
 static int getMaxCivzoneId()
 {
     auto &vec = world->buildings.other[buildings_other_id::ANY_ZONE];
@@ -1058,6 +1068,7 @@ static int getMaxCivzoneId()
 
     return max_id;
 }
+*/
 
 bool Buildings::constructAbstract(df::building *bld)
 {
@@ -1071,14 +1082,17 @@ bool Buildings::constructAbstract(df::building *bld)
     switch (bld->getType())
     {
         case building_type::Stockpile:
+
             if (auto stock = strict_virtual_cast<df::building_stockpilest>(bld))
                 stock->stockpile_number = getMaxStockpileId() + 1;
             break;
 
+/* TODO: understand how this changes for v50
         case building_type::Civzone:
             if (auto zone = strict_virtual_cast<df::building_civzonest>(bld))
                 zone->zone_num = getMaxCivzoneId() + 1;
             break;
+*/
 
         default:
             break;
@@ -1381,6 +1395,7 @@ std::string Buildings::getRoomDescription(df::building *building, df::unit *unit
     CHECK_NULL_POINTER(building);
     // unit can be null
 
+/* TODO: understand how this changes for v50
     if (!building->is_room)
         return "";
 
@@ -1399,6 +1414,7 @@ std::string Buildings::getRoomDescription(df::building *building, df::unit *unit
     }
 
     return vector_get(room_quality_names[btype], size_t(level), string(""));
+*/ return "";
 }
 
 void Buildings::getStockpileContents(df::building_stockpilest *stockpile, std::vector<df::item*> *items)
@@ -1418,7 +1434,9 @@ bool Buildings::isActivityZone(df::building * building)
 {
     CHECK_NULL_POINTER(building);
     return building->getType() == building_type::Civzone
+/* TODO: understand how this changes for v50
             && building->getSubtype() == (short)civzone_type::ActivityZone;
+*/ ;
 }
 
 bool Buildings::isPenPasture(df::building * building)
@@ -1426,35 +1444,45 @@ bool Buildings::isPenPasture(df::building * building)
     if (!isActivityZone(building))
         return false;
 
+/* TODO: understand how this changes for v50
     return ((df::building_civzonest*) building)->zone_flags.bits.pen_pasture != 0;
+*/ return false;
 }
 
 bool Buildings::isPitPond(df::building * building)
 {
     if (!isActivityZone(building))
         return false;
+/* TODO: understand how this changes for v50
     return ((df::building_civzonest*) building)->zone_flags.bits.pit_pond != 0;
+*/ return false;
 }
 
 bool Buildings::isActive(df::building * building)
 {
     if (!isActivityZone(building))
         return false;
+/* TODO: understand how this changes for v50
     return ((df::building_civzonest*) building)->zone_flags.bits.active != 0;
+*/ return false;
 }
 
 bool Buildings::isHospital(df::building * building)
  {
      if (!isActivityZone(building))
          return false;
+/* TODO: understand how this changes for v50
      return ((df::building_civzonest*) building)->zone_flags.bits.hospital != 0;
+*/ return false;
  }
 
  bool Buildings::isAnimalTraining(df::building * building)
  {
      if (!isActivityZone(building))
          return false;
+/* TODO: understand how this changes for v50
      return ((df::building_civzonest*) building)->zone_flags.bits.animal_training != 0;
+*/ return false;
  }
 
 // returns building of pen/pit at cursor position (NULL if nothing found)

--- a/library/modules/Gui.cpp
+++ b/library/modules/Gui.cpp
@@ -50,7 +50,6 @@ using namespace DFHack;
 #include "DataDefs.h"
 
 #include "df/announcement_flags.h"
-#include "df/assign_trade_status.h"
 #include "df/building_cagest.h"
 #include "df/building_civzonest.h"
 #include "df/building_furnacest.h"
@@ -82,36 +81,7 @@ using namespace DFHack;
 #include "df/ui_unit_view_mode.h"
 #include "df/unit.h"
 #include "df/unit_inventory_item.h"
-#include "df/viewscreen_announcelistst.h"
-#include "df/viewscreen_assign_display_itemst.h"
-#include "df/viewscreen_buildinglistst.h"
-#include "df/viewscreen_customize_unitst.h"
-#include "df/viewscreen_dungeon_monsterstatusst.h"
-#include "df/viewscreen_dungeonmodest.h"
 #include "df/viewscreen_dwarfmodest.h"
-#include "df/viewscreen_itemst.h"
-#include "df/viewscreen_joblistst.h"
-#include "df/viewscreen_jobmanagementst.h"
-#include "df/viewscreen_jobst.h"
-#include "df/viewscreen_layer.h"
-#include "df/viewscreen_layer_assigntradest.h"
-#include "df/viewscreen_layer_militaryst.h"
-#include "df/viewscreen_layer_noblelistst.h"
-#include "df/viewscreen_layer_overall_healthst.h"
-#include "df/viewscreen_layer_stockpilest.h"
-#include "df/viewscreen_layer_unit_healthst.h"
-#include "df/viewscreen_layer_unit_relationshipst.h"
-#include "df/viewscreen_locationsst.h"
-#include "df/viewscreen_petst.h"
-#include "df/viewscreen_storesst.h"
-#include "df/viewscreen_textviewerst.h"
-#include "df/viewscreen_tradegoodsst.h"
-#include "df/viewscreen_unitlistst.h"
-#include "df/viewscreen_unitst.h"
-#include "df/viewscreen_reportlistst.h"
-#include "df/viewscreen_treasurelistst.h"
-#include "df/viewscreen_workquota_conditionst.h"
-#include "df/viewscreen_workshop_profilest.h"
 #include "df/world.h"
 
 const size_t MAX_REPORTS_SIZE = 3000; // DF clears old reports to maintain this vector size
@@ -136,10 +106,12 @@ using df::global::ui_menu_width;
 using df::global::ui_sidebar_menus;
 using df::global::world;
 
+/* TODO: understand how this changes for v50
 static df::layer_object_listst *getLayerList(df::viewscreen_layer *layer, int idx)
 {
     return virtual_cast<df::layer_object_listst>(vector_get(layer->layer_objects,idx));
 }
+*/
 
 static std::string getNameChunk(virtual_identity *id, int start, int end)
 {
@@ -343,6 +315,7 @@ DEFINE_GET_FOCUS_STRING_HANDLER(dwarfmode)
             focus += "/List";
         break;
 
+/* TODO: understand how this changes for v50
     case Hauling:
         if (ui->hauling.in_assign_vehicle)
         {
@@ -381,12 +354,14 @@ DEFINE_GET_FOCUS_STRING_HANDLER(dwarfmode)
                 focus += "/Select/" + tag;
         }
         break;
+*/
 
     default:
         break;
     }
 }
 
+/* TODO: understand how this changes for v50
 DEFINE_GET_FOCUS_STRING_HANDLER(dungeonmode)
 {
     using df::global::ui_advmode;
@@ -599,6 +574,7 @@ DEFINE_GET_FOCUS_STRING_HANDLER(workquota_condition)
     if (screen->item_count_edit)
         focus += "/EditCount";
 }
+*/
 
 std::string Gui::getFocusString(df::viewscreen *top)
 {
@@ -637,8 +613,10 @@ bool Gui::default_hotkey(df::viewscreen *top)
     {
         if (strict_virtual_cast<df::viewscreen_dwarfmodest>(top))
             return true;
+/* TODO: understand how this changes for v50
         if (strict_virtual_cast<df::viewscreen_dungeonmodest>(top))
             return true;
+*/
     }
     return false;
 }
@@ -655,15 +633,19 @@ bool Gui::dwarfmode_hotkey(df::viewscreen *top)
 
 bool Gui::unitjobs_hotkey(df::viewscreen *top)
 {
+/* TODO: understand how this changes for v50
     // Require the unit or jobs list
     return !!strict_virtual_cast<df::viewscreen_joblistst>(top) ||
            !!strict_virtual_cast<df::viewscreen_unitlistst>(top);
+*/ return false;
 }
 
 bool Gui::item_details_hotkey(df::viewscreen *top)
 {
+/* TODO: understand how this changes for v50
     // Require the main dwarf mode screen
     return !!strict_virtual_cast<df::viewscreen_itemst>(top);
+*/ return false;
 }
 
 static bool has_cursor()
@@ -796,6 +778,7 @@ df::job *Gui::getSelectedWorkshopJob(color_ostream &out, bool quiet)
 
 bool Gui::any_job_hotkey(df::viewscreen *top)
 {
+/* TODO: understand how this changes for v50
     if (VIRTUAL_CAST_VAR(screen, df::viewscreen_joblistst, top))
         return vector_get(screen->jobs, screen->cursor_pos) != NULL;
 
@@ -803,10 +786,12 @@ bool Gui::any_job_hotkey(df::viewscreen *top)
         return vector_get(screen->jobs[screen->page], screen->cursor_pos[screen->page]) != NULL;
 
     return workshop_job_hotkey(top);
+*/ return false;
 }
 
 df::job *Gui::getSelectedJob(color_ostream &out, bool quiet)
 {
+/* TODO: understand how this changes for v50
     df::viewscreen *top = Core::getTopViewscreen();
 
     if (VIRTUAL_CAST_VAR(screen, df::viewscreen_jobst, top))
@@ -836,6 +821,7 @@ df::job *Gui::getSelectedJob(color_ostream &out, bool quiet)
         return dfscreen->getSelectedJob();
     else
         return getSelectedWorkshopJob(out, quiet);
+*/ return getSelectedWorkshopJob(out, quiet);
 }
 
 df::unit *Gui::getAnyUnit(df::viewscreen *top)
@@ -848,6 +834,7 @@ df::unit *Gui::getAnyUnit(df::viewscreen *top)
     using df::global::ui_building_assign_units;
     using df::global::ui_building_item_cursor;
 
+/* TODO: understand how this changes for v50
     if (VIRTUAL_CAST_VAR(screen, df::viewscreen_unitst, top))
     {
         return screen->unit;
@@ -1101,6 +1088,7 @@ df::unit *Gui::getAnyUnit(df::viewscreen *top)
     default:
         return NULL;
     }
+*/ return NULL;
 }
 
 bool Gui::any_unit_hotkey(df::viewscreen *top)
@@ -1126,6 +1114,7 @@ df::item *Gui::getAnyItem(df::viewscreen *top)
     using df::global::ui_unit_view_mode;
     using df::global::ui_building_item_cursor;
 
+/* TODO: understand how this changes for v50
     if (VIRTUAL_CAST_VAR(screen, df::viewscreen_textviewerst, top))
     {
         // return the main item if the parent screen is a viewscreen_itemst
@@ -1239,6 +1228,7 @@ df::item *Gui::getAnyItem(df::viewscreen *top)
     default:
         return NULL;
     }
+*/ return NULL;
 }
 
 bool Gui::any_item_hotkey(df::viewscreen *top)
@@ -1262,6 +1252,7 @@ df::building *Gui::getAnyBuilding(df::viewscreen *top)
     using df::global::ui_look_list;
     using df::global::ui_look_cursor;
 
+/* TODO: understand how this changes for v50
     if (VIRTUAL_CAST_VAR(screen, df::viewscreen_buildinglistst, top))
         return vector_get(screen->buildings, screen->cursor);
 
@@ -1303,6 +1294,7 @@ df::building *Gui::getAnyBuilding(df::viewscreen *top)
     default:
         return NULL;
     }
+*/ return NULL;
 }
 
 bool Gui::any_building_hotkey(df::viewscreen *top)
@@ -2156,6 +2148,7 @@ bool Gui::setDesignationCoords (const int32_t x, const int32_t y, const int32_t 
 df::coord Gui::getMousePos()
 {
     df::coord pos;
+/* TODO: understand how this changes for v50
     if (gps && gps->mouse_x > -1) {
         // return invalid coords if the cursor is not over the map
         DwarfmodeDims dims = getDwarfmodeViewDims();
@@ -2167,6 +2160,7 @@ df::coord Gui::getMousePos()
         pos.x += gps->mouse_x - 1;
         pos.y += gps->mouse_y - 1;
     }
+*/
     return pos;
 }
 

--- a/library/modules/Items.cpp
+++ b/library/modules/Items.cpp
@@ -92,7 +92,7 @@ using namespace std;
 #include "df/unit_inventory_item.h"
 #include "df/vehicle.h"
 #include "df/vermin.h"
-#include "df/viewscreen_itemst.h"
+#include "df/viewscreen.h"
 #include "df/world.h"
 #include "df/world_site.h"
 #include "df/written_content.h"
@@ -904,6 +904,7 @@ static bool detachItem(MapExtras::MapCache &mc, df::item *item)
             case general_ref_type::CONTAINED_IN_ITEM:
                 if (auto item2 = ref->getItem())
                 {
+/* TODO: understand how this changes for v50
                     // Viewscreens hold general_ref_contains_itemst pointers
                     for (auto screen = Core::getTopViewscreen(); screen; screen = screen->parent)
                     {
@@ -911,7 +912,7 @@ static bool detachItem(MapExtras::MapCache &mc, df::item *item)
                         if (vsitem && vsitem->item == item2)
                             return false;
                     }
-
+*/
                     item2->flags.bits.weight_computed = false;
 
                     removeRef(item2->general_refs, general_ref_type::CONTAINS_ITEM, item->id);

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -79,12 +79,23 @@ using std::string;
 // returns text grid coordinates, even if the game map is scaled differently
 df::coord2d Screen::getMousePos()
 {
-    int32_t a, b, r, f;
-    if (!enabler || !enabler->renderer->get_mouse_coords(&a, &b, &r, &f)) {
+    int32_t pixelx = 0, pixely = 0, tilex = 0, tiley = 0;
+    if (!enabler || !enabler->renderer->get_mouse_coords(
+            &pixelx, &pixely, &tilex, &tiley)) {
         return df::coord2d(-1, -1);
     }
-    std::cerr << "a,b,r,f = " << a << ", " << b << ", " << r << ", " << f << std::endl;
-    return df::coord2d(-1, -1);
+    return df::coord2d(tilex, tiley);
+}
+
+// returns the screen pixel coordinates
+df::coord2d Screen::getMousePixels()
+{
+    int32_t pixelx = 0, pixely = 0, tilex = 0, tiley = 0;
+    if (!enabler || !enabler->renderer->get_mouse_coords(
+            &pixelx, &pixely, &tilex, &tiley)) {
+        return df::coord2d(-1, -1);
+    }
+    return df::coord2d(pixelx, pixely);
 }
 
 df::coord2d Screen::getWindowSize()

--- a/library/modules/Screen.cpp
+++ b/library/modules/Screen.cpp
@@ -79,11 +79,12 @@ using std::string;
 // returns text grid coordinates, even if the game map is scaled differently
 df::coord2d Screen::getMousePos()
 {
-    int32_t x = Renderer::GET_MOUSE_COORDS_SENTINEL, y = (int32_t)true;
-    if (!enabler || !enabler->renderer->get_mouse_coords(&x, &y)) {
+    int32_t a, b, r, f;
+    if (!enabler || !enabler->renderer->get_mouse_coords(&a, &b, &r, &f)) {
         return df::coord2d(-1, -1);
     }
-    return df::coord2d(x, y);
+    std::cerr << "a,b,r,f = " << a << ", " << b << ", " << r << ", " << f << std::endl;
+    return df::coord2d(-1, -1);
 }
 
 df::coord2d Screen::getWindowSize()
@@ -108,6 +109,7 @@ static bool doSetTile_default(const Pen &pen, int x, int y, bool map)
     if (x < 0 || x >= dim.x || y < 0 || y >= dim.y)
         return false;
 
+/* TODO: understand how this changes for v50
     int index = ((x * gps->dimy) + y);
     auto screen = gps->screen + index*4;
     screen[0] = uint8_t(pen.ch);
@@ -119,7 +121,7 @@ static bool doSetTile_default(const Pen &pen, int x, int y, bool map)
     gps->screentexpos_grayscale[index] = (pen.tile_mode == Screen::Pen::TileColor);
     gps->screentexpos_cf[index] = pen.tile_fg;
     gps->screentexpos_cbr[index] = pen.tile_bg;
-
+*/
     return true;
 }
 
@@ -143,6 +145,7 @@ static Pen doGetTile_default(int x, int y, bool map)
     if (x < 0 || x >= dim.x || y < 0 || y >= dim.y)
         return Pen(0,0,0,-1);
 
+/* TODO: understand how this changes for v50
     int index = x*dim.y + y;
     auto screen = gps->screen + index*4;
     if (screen[3] & 0x80)
@@ -168,6 +171,7 @@ static Pen doGetTile_default(int x, int y, bool map)
     }
 
     return pen;
+*/ return Pen(0,0,0,-1);
 }
 
 GUI_HOOK_DEFINE(Screen::Hooks::get_tile, doGetTile_default);


### PR DESCRIPTION
problematic code commented out with the header:
`/* TODO: understand how this changes for v50`

If there were stub return statements added, they appear after the closing `*/` on the same line.

modifications to `Screen` and `Hooks-windows` lovingly stolen from https://github.com/Putnam3145/dfhack/tree/v50

Note the startup crash due to the commandline processing (alignment?) error is still there.